### PR TITLE
Fix the loop of format specifiers

### DIFF
--- a/core_func.c
+++ b/core_func.c
@@ -25,22 +25,22 @@ int _printf(const char *format, ...)
 	{
 		j = 0;
 
-		while (formats[j].fmt != NULL)
+		if (format[i] == '%')
 		{
-			if (format[i] == '%')
+			while (formats[j].fmt != NULL)
 			{
-				i++;
-				if (formats[j].fmt[0] == format[i])
+				if (formats[j].fmt[0] == format[i + 1])
 				{
 					formats[j].function(args);
+					i++;
 					break;
 				}
+				j++;
 			}
-			else
-			{
-				_putchar(format[i]);
-			}
-			j++;
+		}
+		else
+		{
+			_putchar(format[i]);
 		}
 		i++;
 	}

--- a/fmt_handler.c
+++ b/fmt_handler.c
@@ -6,11 +6,11 @@
  * Return: Always 0
  */
 
-int handle_char(va_list args)
+void handle_char(va_list args)
 {
 	char c = va_arg(args, int);
 
-	return (_putchar(c));
+	_putchar(c);
 }
 
 /**
@@ -19,14 +19,13 @@ int handle_char(va_list args)
  * Return: length of string
 */
 
-int handle_string(va_list args)
+void handle_string(va_list args)
 {
 	char *str = va_arg(args, char *);
 	int i;
 
 	for (i = 0; str[i] != '\0'; i++)
 		_putchar(str[i]);
-	return (i);
 
 }
 

--- a/main.h
+++ b/main.h
@@ -15,13 +15,13 @@
 typedef struct fmt_spec
 {
 	char *fmt;
-	int (*function)(va_list);
+	void (*function)(va_list);
 } fmt_spec;
 
 int _printf(const char *format, ...);
 int _putchar (char x);
-int handle_char(va_list args);
-int handle_string(va_list args);
+void handle_char(va_list args);
+void handle_string(va_list args);
 
 
 # endif


### PR DESCRIPTION
The format specifier "loop" or "parser" was not working properly.

I have fixed this but still there is a problem.
If there is no match, the `%` sign is lost.
This is a small issue which will be fixed in subsequent iterations
