### PR TITLE
Fix betty and GNU 89 styling issues

### DIFF
--- a/core_func.c
+++ b/core_func.c
@@ -16,6 +16,7 @@ int _printf(const char *format, ...)
 	fmt_spec formats[] = {
 		{"c", handle_char},
 		{"s", handle_string},
+		{"%", handle_percentage},
 		{NULL, NULL}
 	};
 

--- a/fmt_handler.c
+++ b/fmt_handler.c
@@ -6,9 +6,6 @@
  * Return: Always 0
  */
 
-// let's get started
-
-
 void handle_char(va_list args)
 {
 	char c = va_arg(args, int);
@@ -34,9 +31,9 @@ void handle_string(va_list args)
  * handle_percentage - a function that handles percentage
  * @args: argument passed
  * Return: %
- * 
+ *
 */
-void handle_percentage(__attribute__((UNUSED)) va_list args)
+void handle_percentage(__attribute__((unused)) va_list args)
 {
-    _putchar('%');
+	_putchar('%');
 }

--- a/main.h
+++ b/main.h
@@ -23,6 +23,7 @@ int _printf(const char *format, ...);
 int _putchar (char x);
 void handle_char(va_list args);
 void handle_string(va_list args);
+void handle_percentage(__attribute__((unused)) va_list args);
 
 
 # endif


### PR DESCRIPTION
There were GNU and Betty errors when compiling the program
I have fixed them and added handle_percentage to the list of supported formats.

